### PR TITLE
make debugger expand relative paths to absolute

### DIFF
--- a/include/lrdb/server.hpp
+++ b/include/lrdb/server.hpp
@@ -20,7 +20,7 @@
 
 namespace lrdb {
 
-#define LRDB_SERVER_PROTOCOL_VERSION "2"
+#define LRDB_SERVER_PROTOCOL_VERSION "3"
 
 /// @brief Debug Server Class
 /// template type is messaging communication customization point
@@ -70,6 +70,9 @@ class basic_server {
 
  private:
   void init() {
+    getcwd(working_dir, 4096); // probably will need to check for trailing slash
+    debugger_.set_working_dir(working_dir);
+    
     debugger_.set_pause_handler([&](debugger&) {
       send_pause_status();
       while (debugger_.paused() && command_stream_.is_open()) {
@@ -411,6 +414,7 @@ class basic_server {
     }
   }
 
+  char working_dir[4096];
   bool wait_for_connect_;
   debugger debugger_;
   StreamType command_stream_;


### PR DESCRIPTION
I have encountered issues with setting breakpoints in modules loaded using require, which uses absolute paths.
Using relative paths brings problems in conjunction with the vscode extension, which might find the same file in multiple sourcesRoot directories. Absolute paths would solve this.

debugger class now has a public method set_working_dir, which accepts char*.
If the method is not called, the old behaviour is preserved - relative paths are not expanded.

server class gets cwd in main and handles it to the debugger.